### PR TITLE
Feat: GeoLocation API 연동 및 사용자 위치 표시

### DIFF
--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -47,7 +47,8 @@ const useGeolocation = () => {
         error: errorMessage,
       }));
     };
-    navigator.geolocation.getCurrentPosition(successCallback, errorCallback);
+    // navigator.geolocation.getCurrentPosition(successCallback, errorCallback);
+    navigator.geolocation.watchPosition(successCallback, errorCallback);
   }, []);
   return locationState;
 };

--- a/src/hooks/useLocation.ts
+++ b/src/hooks/useLocation.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react'
+
+interface GeoLocationState {
+  lat: number | null;
+  lng: number | null;
+  error: string | null;
+}
+
+const useGeolocation = () => {
+  const [locationState, setLocationState] = useState<GeoLocationState>({
+    lat: null,
+    lng: null,
+    error: null,
+  })
+  useEffect(() => {
+    if(!navigator.geolocation) {
+      console.error("현재 브라우저는 GeoLocation API를 지원하지 않습니다.");
+      setLocationState(prev => ({
+        ...prev,
+        error: "현재 브라우저는 GeoLocation API를 지원하지 않습니다."
+      }));
+    }
+
+    // 위치 요청 성공시 실행되는 콜백함수
+    const successCallback = (postion: GeolocationPosition) => {
+      const lat = postion.coords.latitude;
+      const lng = postion.coords.longitude;
+
+      console.log("사용자의 현재 위치 가져오기 성공");
+      console.log(`위도 (Latitude): ${lat}, 경도 (Longitude): ${lng}`);
+
+      setLocationState({lat,lng, error: null});
+    };
+
+    const errorCallback = (error: GeolocationPositionError) => {
+      let errorMessage = `ERROR(${error.code}): ${error.message}`;
+      if (error.code === error.PERMISSION_DENIED) {
+        errorMessage = "사용자가 위치 정보 접근을 거부했습니다.";
+      } else if (error.code === error.POSITION_UNAVAILABLE) {
+        errorMessage = "위치 정보를 사용할 수 없습니다.";
+      } else if (error.code === error.TIMEOUT) {
+        errorMessage = "위치 요청 시간이 초과되었습니다.";
+      }
+      console.error(`useGeolocation: ${errorMessage}`);
+      setLocationState(prev => ({
+        ...prev,
+        error: errorMessage,
+      }));
+    };
+    navigator.geolocation.getCurrentPosition(successCallback, errorCallback);
+  }, []);
+  return locationState;
+};
+
+export default useGeolocation;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -2,19 +2,9 @@ import { useState } from "react";
 import NaverMap from "../../shared/components/Map";
 import LocationSelector from "../../shared/components/LocationSelector";
 import SearchBar from "../../shared/components/SearchBar";
-// import LocationFetcher from '../../shared/components/LocationFetcher';
+import type { Building } from "../../types/Building";
 
-interface Building {
-  _id: string;
-  name: string;
-  code: string;
-  coordinates: {
-    lat: number;
-    lng: number;
-  };
-}
-
-function index() {
+function Index() {
   const [buildings, setBuildings] = useState<Building[]>([]);
   const [selectedBuilding, setSelectedBuilding] = useState<Building | null>(null);
   return (
@@ -31,4 +21,4 @@ function index() {
   );
 }
 
-export default index;
+export default Index;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import NaverMap from "../../shared/components/Map";
 import LocationSelector from "../../shared/components/LocationSelector";
 import SearchBar from "../../shared/components/SearchBar";
+import LocationFetcher from '../../shared/components/LocationFetcher';
 
 interface Building {
   _id: string;
@@ -21,6 +22,7 @@ function index() {
       <SearchBar buildings={buildings} onSearch={setSelectedBuilding} />
       <div className="relative h-screen">
         <NaverMap onBuildingsLoaded={setBuildings} selectedBuilding={selectedBuilding} />
+        <LocationFetcher />
         <div className="fixed bottom-0 left-0 right-0 z-[9999] bg-p-white rounded-t-24">
           <LocationSelector />
         </div>

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import NaverMap from "../../shared/components/Map";
 import LocationSelector from "../../shared/components/LocationSelector";
 import SearchBar from "../../shared/components/SearchBar";
-import LocationFetcher from '../../shared/components/LocationFetcher';
+// import LocationFetcher from '../../shared/components/LocationFetcher';
 
 interface Building {
   _id: string;
@@ -22,7 +22,7 @@ function index() {
       <SearchBar buildings={buildings} onSearch={setSelectedBuilding} />
       <div className="relative h-screen">
         <NaverMap onBuildingsLoaded={setBuildings} selectedBuilding={selectedBuilding} />
-        <LocationFetcher />
+        {/* <LocationFetcher /> */}
         <div className="fixed bottom-0 left-0 right-0 z-[9999] bg-p-white rounded-t-24">
           <LocationSelector />
         </div>

--- a/src/shared/components/LocationFetcher.tsx
+++ b/src/shared/components/LocationFetcher.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+
+const LocationFetcher = () => {
+  useEffect(() => {
+    if(navigator.geolocation) {
+      console.log("GeoLocation API 지원 확인");
+
+      navigator.geolocation.getCurrentPosition (
+        // 위치 요청 성공 여부에 따른 콜백 함수
+        (position) => {
+          const lat = position.coords.latitude // 위도
+          const lng = position.coords.longitude // 경도
+
+          console.log("사용자 현재 위치 가져오기 성공!");
+          console.log(`위도 (Latitude): ${lat}`);
+          console.log(`경도 (Longitude): ${lng}`);
+        }, 
+        (error) => {
+          console.error("현재 위치 가져오기 실패", error.message);
+          if (error.code === error.PERMISSION_DENIED) {
+            console.warn("이유: 사용자가 위치 정보 접근을 거부했습니다.");
+          } else if (error.code === error.POSITION_UNAVAILABLE) {
+            console.warn("이유: 위치 정보를 사용할 수 없습니다.");
+          } else if (error.code === error.TIMEOUT) {
+            console.warn("이유: 위치 요청 시간이 초과되었습니다.");
+          }
+        }
+      )
+    }
+  }, [])
+
+  return null;
+}
+
+export default LocationFetcher

--- a/src/shared/components/SearchBar.tsx
+++ b/src/shared/components/SearchBar.tsx
@@ -67,6 +67,7 @@ const SearchBar = ({
         </div>
       </div>
       {/* 토스트 메시지 */}
+
       <AnimatePresence>
         {showToast && <ToastMessage message={toastMessage} duration={1500} onClose={() => setShowToast(false)} />}
       </AnimatePresence>

--- a/src/shared/components/SearchBar.tsx
+++ b/src/shared/components/SearchBar.tsx
@@ -2,17 +2,7 @@ import { useState } from "react";
 import { Search } from "lucide-react";
 import ToastMessage from './ToastMessage';
 import { AnimatePresence } from "framer-motion";
-
-interface Building {
-  _id: number;
-  name: string;
-  code: string;
-  coordinates: {
-    lat: number;
-    lng: number;
-  };
-}
-
+import type { Building } from "../../types/Building";
 interface SearchBarProps {
   placeholder?: string;
   buildings: Building[];

--- a/src/types/Building.ts
+++ b/src/types/Building.ts
@@ -1,0 +1,9 @@
+export interface Building {
+  _id: string;
+  name: string;
+  code: string;
+  coordinates: {
+    lat: number;
+    lng: number;
+  };
+}

--- a/src/types/naver-maps.d.ts
+++ b/src/types/naver-maps.d.ts
@@ -2,6 +2,7 @@ declare global {
   interface Window {
     naver : any;
   }
+  const naver: typeof import("navermaps");
 }
 
 export {};


### PR DESCRIPTION
### 🚀 변경 사항
[Feat] GeoLocation API 연동 및 사용자 위치 표시 #18 

### ✅ 체크리스트
- [x] GeoLocation API 연동
- [x] 컴포넌트 초기 빌드 및 커스텀 훅 마이그레이션
- [x] Map 컴포넌트 유저 위치 표시 마커 로직 구현
- [x] 학교 건물 타입 전역 세팅 
- [ ] 코드 리뷰 완료
- [x] 테스트 통과 확인

### 💡 주요 변경 내용
```
import { useEffect } from 'react'

const LocationFetcher = () => {
  useEffect(() => {
    if(navigator.geolocation) {
      console.log("GeoLocation API 지원 확인");

      navigator.geolocation.getCurrentPosition (
        // 위치 요청 성공 여부에 따른 콜백 함수
        (position) => {
          const lat = position.coords.latitude // 위도
          const lng = position.coords.longitude // 경도

          console.log("사용자 현재 위치 가져오기 성공!");
          console.log(`위도 (Latitude): ${lat}`);
          console.log(`경도 (Longitude): ${lng}`);
        }, 
        (error) => {
        ... 중간생략
          }
        }
      )
    }
  }, [])

  return null;
}

export default LocationFetcher
```
API 연동을 위한 테스트용 컴포넌트
MDN 문서 참고하여 useGeolocation 비동기 함수를 통해 position, error 콜백 함수 반환

```
const useGeolocation = () => {
  const [locationState, setLocationState] = useState<GeoLocationState>({
    lat: null,
    lng: null,
    error: null,
  })
  useEffect(() => {
    if(!navigator.geolocation) {
      console.error("현재 브라우저는 GeoLocation API를 지원하지 않습니다.");
      setLocationState(prev => ({
        ...prev,
        error: "현재 브라우저는 GeoLocation API를 지원하지 않습니다."
      }));
    }

    // 위치 요청 성공시 실행되는 콜백함수
    const successCallback = (postion: GeolocationPosition) => {
      const lat = postion.coords.latitude;
      const lng = postion.coords.longitude;

      setLocationState({lat,lng, error: null});
    };

    const errorCallback = (error: GeolocationPositionError) => {
      let errorMessage = `ERROR(${error.code}): ${error.message}`;
      ... 중간 생략
      console.error(`useGeolocation: ${errorMessage}`);
      setLocationState(prev => ({
        ...prev,
        error: errorMessage,
      }));
    };
```
아직 1차 MVP 단계에서는 사용자의 위치를 가져오는 로직을 재사용하는 기능은 따로 없지만 
추후 리팩토링 과정에서 재사용이 필요하다고 생각했습니다. 
코드의 재사용성, 관심사 분리 및 코드 간결화, 상태의 캡슐화를 위해 기존의 컴포넌트 로직을 커스텀 훅으로 마이그레이션 진행하였습니다. 

그리고 지도 서비스의 특성상 유저의 위치가 변경될때 실시간으로 해당 위치를 파악하기 위해 
기존 getCurrentPosition의 사용자의 위치를 한번만 가져오고 종료되는 문제점을 
watchPosition을 사용하여 사용자의 위치가 변경될떄마다 successCallback를 호출하여 위치를 변경하는 장점이 있어 
리팩토링을 진행하였습니다. 



### 📸 스크린샷
<!-- 이미지를 여기에 드래그 앤 드롭하거나 붙여넣기 하세요 -->
<img width="993" height="474" alt="image" src="https://github.com/user-attachments/assets/bf9d6857-3109-43f4-ad47-3896d2d4ba72" />

### 📎 관련 링크
- Closes #18 