### PR TITLE
Feat: 네이버 지도 PolyLine 세팅

### DIFF
--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -7,24 +7,23 @@ import type { Building } from "../../types/Building";
 function Index() {
   const [buildings, setBuildings] = useState<Building[]>([]);
   const [selectedBuilding, setSelectedBuilding] = useState<Building | null>(null);
-
   const [routeQuery, setRouteQuery] = useState<{start: string, end: string} | null>(null);
 
   return (
     <div>
       <SearchBar buildings={buildings} onSearch={setSelectedBuilding} />
       <div className="relative h-screen">
-        <NaverMap 
-          onBuildingsLoaded={setBuildings} 
-          selectedBuilding={selectedBuilding} 
-          routeQuery={routeQuery} 
-        />
+        <NaverMap onBuildingsLoaded={setBuildings} selectedBuilding={selectedBuilding} routeQuery={routeQuery} />
         {/* <LocationFetcher /> */}
         <div className="fixed bottom-0 left-0 right-0 z-[9999] bg-p-white rounded-t-24">
           <LocationSelector
             onRouteSearch={(start, end) => {
               console.log("경로 검색:", start, "→", end);
               setRouteQuery({ start, end });
+            }}
+            onRouteClear={() => {
+              console.log("경로 초기화");
+              setRouteQuery(null);
             }}
           />
         </div>

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -7,14 +7,26 @@ import type { Building } from "../../types/Building";
 function Index() {
   const [buildings, setBuildings] = useState<Building[]>([]);
   const [selectedBuilding, setSelectedBuilding] = useState<Building | null>(null);
+
+  const [routeQuery, setRouteQuery] = useState<{start: string, end: string} | null>(null);
+
   return (
     <div>
       <SearchBar buildings={buildings} onSearch={setSelectedBuilding} />
       <div className="relative h-screen">
-        <NaverMap onBuildingsLoaded={setBuildings} selectedBuilding={selectedBuilding} />
+        <NaverMap 
+          onBuildingsLoaded={setBuildings} 
+          selectedBuilding={selectedBuilding} 
+          routeQuery={routeQuery} 
+        />
         {/* <LocationFetcher /> */}
         <div className="fixed bottom-0 left-0 right-0 z-[9999] bg-p-white rounded-t-24">
-          <LocationSelector />
+          <LocationSelector
+            onRouteSearch={(start, end) => {
+              console.log("경로 검색:", start, "→", end);
+              setRouteQuery({ start, end });
+            }}
+          />
         </div>
       </div>
     </div>

--- a/src/shared/components/LocationSelector.tsx
+++ b/src/shared/components/LocationSelector.tsx
@@ -1,32 +1,30 @@
 import { useState } from 'react'
 
-// interface Building {
-//   _id: string;
-//   name: string;
-//   code: string;
-//   coordinates: {
-//     lat: number;
-//     lng: number;
-//   };
-// }
-
 interface LocationSelectorProps {
   // buildings: Building[]; // 자동완성용
   onRouteSearch: (start: string, end: string) => void; // 검색 결과 전달
+  onRouteClear : () => void;
 }
 
-const LocationSelector = ({ onRouteSearch }: LocationSelectorProps) => {
+const LocationSelector = ({ onRouteSearch, onRouteClear }: LocationSelectorProps) => {
   const [start, setStart] = useState<string>("");
   const [end, setEnd] = useState<string>("");
+  const [isRouteActive, setIsRouteActive] = useState<boolean>(false);
 
   const handleSearchRoute = () => {
-    if (!start || !end) {
-      // 토스트: "출발지와 도착지를 입력하세요"
-      return;
+    if (isRouteActive) {
+      console.log("경로 종료");
+      onRouteClear();
+      setIsRouteActive(false);
+    } else {
+        if (!start || !end) {
+        alert('출발지와 도착지를 입력하세요');
+        return;
+      }
+      // Main으로 전달
+      onRouteSearch(start, end);
+      setIsRouteActive(true)
     }
-
-    // Main으로 전달
-    onRouteSearch(start, end);
   };
   return (
     <div className="px-16 py-16">
@@ -39,6 +37,7 @@ const LocationSelector = ({ onRouteSearch }: LocationSelectorProps) => {
             value={start}
             onChange={(e) => setStart(e.target.value)}
             placeholder="출발지를 입력하세요 (예: 7호관)"
+            disabled={isRouteActive} 
             className="flex-1 px-12 py-12 text-gray-600 bg-gray-100 outline-none text-14 rounded-8"
           />
         </div>
@@ -50,6 +49,7 @@ const LocationSelector = ({ onRouteSearch }: LocationSelectorProps) => {
             value={end}
             onChange={(e) => setEnd(e.target.value)}
             placeholder="도착지를 입력하세요 (예: 본관)"
+            disabled={isRouteActive} 
             className="flex-1 px-12 py-12 text-gray-600 bg-gray-100 outline-none text-14 rounded-8"
           />
         </div>
@@ -59,7 +59,7 @@ const LocationSelector = ({ onRouteSearch }: LocationSelectorProps) => {
         onClick={handleSearchRoute}
         className="w-full py-16 mt-20 font-bold text-white bg-primary-600 rounded-[10px] text-17"
       >
-        길 안내 시작
+        {isRouteActive ? '길 안내 종료' : '길 안내 시작'}
       </button>
     </div>
   );

--- a/src/shared/components/LocationSelector.tsx
+++ b/src/shared/components/LocationSelector.tsx
@@ -1,13 +1,33 @@
 import { useState } from 'react'
 
-const LocationSelector = () => {
-  const [startLocation, setStartLocation] = useState<string>('');
-  const [endLocation, setEndLocation] = useState<string>('');
+// interface Building {
+//   _id: string;
+//   name: string;
+//   code: string;
+//   coordinates: {
+//     lat: number;
+//     lng: number;
+//   };
+// }
 
-  // TODO : 추후 API 연동
+interface LocationSelectorProps {
+  // buildings: Building[]; // 자동완성용
+  onRouteSearch: (start: string, end: string) => void; // 검색 결과 전달
+}
+
+const LocationSelector = ({ onRouteSearch }: LocationSelectorProps) => {
+  const [start, setStart] = useState<string>("");
+  const [end, setEnd] = useState<string>("");
+
   const handleSearchRoute = () => {
-    console.log("길 안내 시작");
-  }
+    if (!start || !end) {
+      // 토스트: "출발지와 도착지를 입력하세요"
+      return;
+    }
+
+    // Main으로 전달
+    onRouteSearch(start, end);
+  };
   return (
     <div className="px-16 py-16">
       <div className="bg-p-white rounded-[10px] overflow-hidden shadow-[0, 2px, 8px, rgba(0,0,0,01)]">
@@ -16,8 +36,8 @@ const LocationSelector = () => {
           <label className="font-bold text-17 text-primary-600">출발</label>
           <input
             type="text"
-            value={startLocation}
-            onChange={(e) => setStartLocation(e.target.value)}
+            value={start}
+            onChange={(e) => setStart(e.target.value)}
             placeholder="출발지를 입력하세요 (예: 7호관)"
             className="flex-1 px-12 py-12 text-gray-600 bg-gray-100 outline-none text-14 rounded-8"
           />
@@ -27,8 +47,8 @@ const LocationSelector = () => {
           <label className="font-bold text-17 text-primary-600">도착</label>
           <input
             type="text"
-            value={endLocation}
-            onChange={(e) => setEndLocation(e.target.value)}
+            value={end}
+            onChange={(e) => setEnd(e.target.value)}
             placeholder="도착지를 입력하세요 (예: 본관)"
             className="flex-1 px-12 py-12 text-gray-600 bg-gray-100 outline-none text-14 rounded-8"
           />
@@ -43,6 +63,6 @@ const LocationSelector = () => {
       </button>
     </div>
   );
-}
+};
 
 export default LocationSelector

--- a/src/shared/components/Map.tsx
+++ b/src/shared/components/Map.tsx
@@ -17,15 +17,87 @@ interface Building {
 interface NaverMapProps {
   onBuildingsLoaded?: (buildings: Building[]) => void;
   selectedBuilding?: Building | null;
+  routeQuery?: {start: string, end: string} | null;
 }
 
-const NaverMap = ({ onBuildingsLoaded, selectedBuilding }: NaverMapProps) => {
+const NaverMap = ({ onBuildingsLoaded, selectedBuilding, routeQuery }: NaverMapProps) => {
   const userMarkerRef = useRef<naver.maps.Marker | null>(null);
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstanceRef = useRef<naver.maps.Map | null>(null);
+
   const [isLoaded, setIsLoaded] = useState(false);
   const [buildings, setBuildings] = useState<Building[]>([]);
+
+  const [routePath, setRoutePath] = useState<any>(null);
+  const polylineRef = useRef<any>(null);
+
   const { lat, lng, error } = useGeolocation();
+
+  // 폴리라인 lat, lng 값 호출하기
+  useEffect(() => {
+    if (!routeQuery) return;
+    if (!isLoaded) return;
+
+    const routeKey = `${routeQuery?.start}-${routeQuery?.end}`;
+    console.log("경로 조회 : ", routeQuery);
+
+    axios
+      .get(`http://localhost:5000/api/routes/${routeKey}`)
+      .then((res) => {
+        if (res.data.success) {
+          setRoutePath(res.data.data);
+        } else {
+          console.log("해당 경로를 찾을 수 없습니다.");
+        }
+      })
+      .catch((err) => {
+        console.error("경로 없음", err);
+      });
+  }, [routeQuery, isLoaded]);
+
+  // 폴리라인 그리기
+  useEffect(() => {
+    if (!routePath) return;
+    if (!mapInstanceRef.current) return;
+
+    console.log("폴리라인 그리기 시작");
+
+    // 기존 폴리라인 제거
+    if (polylineRef.current) {
+      polylineRef.current.setMap(null);
+      console.log("이전 폴리라인 제거");
+    }
+
+    // path 배열을 네이버 LatLng로 변환
+    const pathCoords = routePath.path
+      .sort((a: any, b: any) => a.order - b.order) // order 순서대로 정렬
+      .map((point: any) => new (window as any).naver.maps.LatLng(point.lat, point.lng));
+
+    console.log("📍 좌표 개수:", pathCoords.length);
+
+    // Polyline 생성
+    const polyline = new (window as any).naver.maps.Polyline({
+      map: mapInstanceRef.current,
+      path: pathCoords,
+      strokeColor: "#5347AA", // 보라색
+      strokeWeight: 5, // 굵기
+      strokeOpacity: 0.8, // 투명도
+      strokeStyle: "solid", // 실선
+    });
+
+    polylineRef.current = polyline;
+
+    // 출발지 중심으로 지도 이동
+    const startPos = new (window as any).naver.maps.LatLng(
+      routePath.start_building.coordinates.lat,
+      routePath.start_building.coordinates.lng
+    );
+
+    mapInstanceRef.current.setCenter(startPos);
+    mapInstanceRef.current.setZoom(19);
+
+    console.log("폴리라인 그리기 완료!");
+  }, [routePath]);
 
   // 네이버 지도 스크립트 로드
   useEffect(() => {
@@ -65,7 +137,7 @@ const NaverMap = ({ onBuildingsLoaded, selectedBuilding }: NaverMapProps) => {
       maxZoom: 20,
     };
     const map = new naver.maps.Map(mapRef.current, mapOptions);
-    mapInstanceRef.current = map; 
+    mapInstanceRef.current = map;
 
     buildings.forEach((building) => {
       const markerPosition = new naver.maps.LatLng(building.coordinates.lat, building.coordinates.lng);
@@ -100,7 +172,7 @@ const NaverMap = ({ onBuildingsLoaded, selectedBuilding }: NaverMapProps) => {
 
     if (!userMarkerRef.current) {
       // 1. 마커가 없으면 (최초 1회 실행): 사용자 위치 마커 생성
-      console.log("🟢 현재 위치 마커 생성");
+      console.log("현재 위치 마커 생성");
 
       userMarkerRef.current = new naver.maps.Marker({
         position: userPosition,
@@ -121,7 +193,7 @@ const NaverMap = ({ onBuildingsLoaded, selectedBuilding }: NaverMapProps) => {
       console.log("현재 위치 마커 업데이트");
       userMarkerRef.current.setPosition(userPosition);
     }
-  }, [lat, lng, mapInstanceRef.current, error])
+  }, [lat, lng, mapInstanceRef.current, error]);
   return (
     <div className="w-full h-screen">
       <div ref={mapRef} className="w-full h-full" />

--- a/src/shared/components/Map.tsx
+++ b/src/shared/components/Map.tsx
@@ -83,7 +83,7 @@ const NaverMap = ({ onBuildingsLoaded, selectedBuilding, routeQuery }: NaverMapP
       .sort((a: any, b: any) => a.order - b.order) // order 순서대로 정렬
       .map((point: any) => new (window as any).naver.maps.LatLng(point.lat, point.lng));
 
-    console.log("📍 좌표 개수:", pathCoords.length);
+    console.log("좌표 개수:", pathCoords.length);
 
     // Polyline 생성
     const polyline = new (window as any).naver.maps.Polyline({
@@ -181,7 +181,7 @@ const NaverMap = ({ onBuildingsLoaded, selectedBuilding, routeQuery }: NaverMapP
     const userPosition = new naver.maps.LatLng(lat, lng);
 
     if (!userMarkerRef.current) {
-      // 1. 마커가 없으면 (최초 1회 실행): 사용자 위치 마커 생성
+      // 1. 마커가 없으면: 사용자 위치 마커 생성
       console.log("현재 위치 마커 생성");
 
       userMarkerRef.current = new naver.maps.Marker({

--- a/src/shared/components/Map.tsx
+++ b/src/shared/components/Map.tsx
@@ -35,7 +35,10 @@ const NaverMap = ({ onBuildingsLoaded, selectedBuilding, routeQuery }: NaverMapP
 
   // 폴리라인 lat, lng 값 호출하기
   useEffect(() => {
-    if (!routeQuery) return;
+    if (!routeQuery){
+      setRoutePath(null);
+      return;
+    }
     if (!isLoaded) return;
 
     const routeKey = `${routeQuery?.start}-${routeQuery?.end}`;
@@ -57,7 +60,14 @@ const NaverMap = ({ onBuildingsLoaded, selectedBuilding, routeQuery }: NaverMapP
 
   // 폴리라인 그리기
   useEffect(() => {
-    if (!routePath) return;
+    if (!routePath) {
+      if (polylineRef.current) {
+        polylineRef.current.setMap(null);
+        polylineRef.current = null;
+        console.log("폴리라인 제거됨");
+      }
+      return; 
+    }
     if (!mapInstanceRef.current) return;
 
     console.log("폴리라인 그리기 시작");


### PR DESCRIPTION
### 🚀 변경 사항
[Feat] 네이버 지도 PolyLine 세팅 #12 

### ✅ 체크리스트
### 1. 경로 폴리라인 표시
- [x] 출발지/도착지 입력 시 백엔드 API 호출
- [x] 네이버 지도에 폴리라인으로 경로 시각화
- [x] 출발지 중심으로 지도 자동 이동

### 2. 토글 기능
- [x] "길 안내 시작/종료" 버튼으로 경로 on/off
- [x] 경로 표시 중 입력창 비활성화
- [o] 코드 리뷰 완료
- [x] 테스트 통과 확인

## 데이터 흐름
```
LocationSelector (출발/도착 입력) -> 
"길 안내 시작" 클릭 -> 
Main (routeQuery 상태 업데이트) -> 
NaverMap (API 호출) -> 
GET /api/routes/출발지-도착지 -> 
폴리라인 생성 & 지도에 표시 -> 
"길 안내 종료" 클릭 ->
routeQuery = null -> 
폴리라인 제거
```
### 네이버 지도 Polyline API 활용
```ts
// NaverMap 컴포넌트에서 폴리라인 생성
const polyline = new naver.maps.Polyline({
  map: mapInstanceRef.current,
  path: pathCoords,
});
```
네이버 지도 API의 Polyline 객체를 사용하여 좌표 배열을 연결한 선을 지도에 표시합니다. path 속성에 `naver.maps.LatLng` 객체 배열을 전달하면 해당 좌표들을 순서대로 연결한 경로가 시각화됩니다.

### 백엔드 API 연동을 통한 경로 데이터 조회
```ts
useEffect(() => {
  if (!routeQuery) {
    setRoutePath(null);
    return;
  }
  
  const routeKey = `${routeQuery.start}-${routeQuery.end}`;
  
  axios.get(`http://localhost:5000/api/routes/${routeKey}`)
    .then((res) => {
      if (res.data.success) {
        setRoutePath(res.data.data);
      }
    })
    .catch((err) => {
      console.error("경로 조회 실패:", err);
    });
}, [routeQuery, isLoaded]);
```
사용자가 입력한 start, end 정보를 기반으로 백엔드 서버에 GET 요청을 진행합니다. 
의존성 배열에 routeQuery를 추가하여 상태가 변경될 때 마다 새로운 경로를 가져오며, null인 경우 폴리라인을 제거합니다.

### API 응답 구조
<img width="569" height="465" alt="image" src="https://github.com/user-attachments/assets/d70dbf70-0d5a-4621-ba98-f647d852a3a1" />

###  useRef를 사용하여 폴리라인 관리
```ts
const polylineRef = useRef<any>(null);

useEffect(() => {
  // 기존 폴리라인 제거
  if (polylineRef.current) {
    polylineRef.current.setMap(null);
  }
  
  // 새 폴리라인 생성
  const polyline = new naver.maps.Polyline({...});
  polylineRef.current = polyline;
  
}, [routePath]);
```
새로운 경로를 불러오기 위해서는 기존의 경로를 삭제해야 하므로 useRef를 사용하여 폴리라인 객체의 참조를 유지합니다. 
setMap(null)을 호출하면 지도에서 폴리라인이 제거되어 리렌더링에 상관없이 동일한 폴리라인 객체에 접근할 수 있습니다.

#### useRef를 선택한 이유
- 리렌더링 시에도 폴리라인 객체 참조 유지
- 상태로 관리할 경우 불필요한 리렌더링 발생

### 토글 기능을 통한 사용자 경험 개선
```ts
const [isRouteActive, setIsRouteActive] = useState<boolean>(false);

const handleSearchRoute = () => {
  if (isRouteActive) {
    // 경로 종료
    onRouteClear();
    setIsRouteActive(false);
  } else {
    // 경로 시작
    if (!start || !end) {
      alert('출발지와 도착지를 입력하세요');
      return;
    }
    onRouteSearch(start, end);
    setIsRouteActive(true);
  }
};
```
초기 로직은 사용자가 새로고침을 해야만 기존 경로가 사라지는 방식이라 사용자 경험이 떨어진다고 판단하였고 
isActiveRoute 상태를 도입하여 하나의 버튼으로 경로 검색 / 종료를 할 수 있도록 변경하였습니다. 

#### 길 안내 전
<img width="307" height="171" alt="image" src="https://github.com/user-attachments/assets/c7e49649-92ca-4015-84df-76e7c23123b6" />

#### 길 안내 후 
<img width="308" height="172" alt="image" src="https://github.com/user-attachments/assets/4fb7ae5c-36a8-4ffa-8145-6437303f716d" />




### 📸 스크린샷
<img width="457" height="572" alt="image" src="https://github.com/user-attachments/assets/de73b113-5944-4272-9da4-4c10ad89e826" />


### 📎 관련 링크
- Closes #이슈번호